### PR TITLE
Update Elixir version requirement to ~> 1.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Tdig.MixProject do
       app: :tdig,
       version: "0.3.0",
       name: "Tdig",
-      elixir: "~> 1.12",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: [{@app, release()}],
@@ -33,7 +33,7 @@ defmodule Tdig.MixProject do
   defp deps do
     [
       {:bakeware, "~> 0.2.3", runtime: false},
-      {:tenbin_dns, git: "https://github.com/smkwlab/tenbin_dns.git", tag: "0.5.4"},
+      {:tenbin_dns, git: "https://github.com/smkwlab/tenbin_dns.git", tag: "0.7.0"},
       {:socket, "~> 0.3.13"},
       {:zoneinfo, "~> 0.1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,13 @@
 %{
   "bakeware": {:hex, :bakeware, "0.2.3", "d8124d46af0450633844c997af15edb8b97ac5a8349650a31b41e96803027838", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "df060a008ca4af6f0913ca85891b26caac4afdfa900f886ade6fa8e3ebaf7d7e"},
+  "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
+  "credo": {:hex, :credo, "1.7.12", "9e3c20463de4b5f3f23721527fcaf16722ec815e70ff6c60b86412c695d426c1", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8493d45c656c5427d9c729235b99d498bd133421f3e0a683e5c1b561471291e5"},
+  "dialyxir": {:hex, :dialyxir, "1.4.5", "ca1571ac18e0f88d4ab245f0b60fa31ff1b12cbae2b11bd25d207f865e8ae78a", [:mix], [{:erlex, ">= 0.2.7", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b0fb08bb8107c750db5c0b324fa2df5ceaa0f9307690ee3c1f6ba5b9eb5d35c3"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
+  "erlex": {:hex, :erlex, "0.2.7", "810e8725f96ab74d17aac676e748627a07bc87eb950d2b83acd29dc047a30595", [:mix], [], "hexpm", "3ed95f79d1a844c3f6bf0cea61e0d5612a42ce56da9c03f01df538685365efb0"},
+  "file_system": {:hex, :file_system, "1.1.0", "08d232062284546c6c34426997dd7ef6ec9f8bbd090eb91780283c9016840e8f", [:mix], [], "hexpm", "bfcf81244f416871f2a2e15c1b515287faa5db9c6bcf290222206d120b3d43f6"},
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
-  "tenbin_dns": {:git, "https://github.com/smkwlab/tenbin_dns.git", "8ed9580119390a7d3b1cc3defa850485b05592a3", [tag: "0.3.4"]},
+  "tenbin_dns": {:git, "https://github.com/smkwlab/tenbin_dns.git", "93c20489b1cf9a05548b9403b7fc3fc60b51912f", [tag: "0.7.0"]},
   "zoneinfo": {:hex, :zoneinfo, "0.1.4", "45993b51504a8b0bf0104879a9905776f5ccece99f8389cee34ff203e9f2eca0", [:mix], [], "hexpm", "3725fe8966a3fb3830c596f646c35bae21e79495098dc8f9077531d1baf272db"},
 }


### PR DESCRIPTION
## Summary
- Update Elixir version requirement from ~> 1.12 to ~> 1.17

## Motivation
This change aligns with Ubuntu 22.04 LTS standard Elixir version for better compatibility with standard Linux distributions, consistent with tenbin_dns and tenbin_ex updates.

## Test plan
- [x] All tests pass (31 tests)
- [x] Dependencies compile successfully
- [x] No breaking changes in functionality